### PR TITLE
Add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,3 @@
-
 {
   "name": "garyjones/genesis-header-nav",
   "description": "WordPress plugin that registers a menu location and displays it inside the header for a Genesis Framework child theme.",

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,24 @@
+
+{
+  "name": "garyjones/genesis-header-nav",
+  "description": "WordPress plugin that registers a menu location and displays it inside the header for a Genesis Framework child theme.",
+  "keywords": ["genesis", "genesis-header-nav", "navigation"],
+  "type": "wordpress-plugin",
+  "homepage": "https://github.com/garyjones/genesis-header-nav",
+  "license": "GPL-2.0+",
+  "authors": [
+    {
+      "name": "Gary Jones",
+      "homepage": "https://gamajo.com",
+      "role": "Developer"
+    }
+  ],
+  "support": {
+    "issues": "https://github.com/garyjones/genesis-header-nav/issues",
+    "source": "https://github.com/garyjones/genesis-header-nav"
+  },
+  "require": {
+    "composer/installers": "^1.0",
+    "php": ">=5.3.4"
+  }
+}


### PR DESCRIPTION
Would like to pull this plugin into my project using WPStarter, however this process relies upon the plugin having a valid `composer.json` file. This PR adds a basic `composer.json`.
